### PR TITLE
Skip targets outside of scanrange

### DIFF
--- a/R/xcmsRaw.R
+++ b/R/xcmsRaw.R
@@ -1172,6 +1172,14 @@ setMethod("findPeaks.centWave", "xcmsRaw", function(object, ppm=25, peakwidth=c(
       for (ti in 1:length(targets)) {
         target <- targets[[ti]]
         rtrange <- target$rtrange
+        if(rtrange[1] < scanrange[1]) {
+            cat("Warning: scanrange of ", rtrange[1], "less than minimum rtrange in file. Target ignored.\n")
+            next
+        }
+        if(rtrange[2] > scanrange[2]) {
+            cat("Warning: scanrange of ", rtrange[2], "greater than maximum rtrange in file. Target ignored.\n")
+            next
+        }
         mzrange <- target$mzrange
         t_peakwidth <- target$peakwidth
         if (is.null(t_peakwidth)) t_peakwidth <- peakwidth

--- a/R/xcmsRaw.R
+++ b/R/xcmsRaw.R
@@ -1172,14 +1172,6 @@ setMethod("findPeaks.centWave", "xcmsRaw", function(object, ppm=25, peakwidth=c(
       for (ti in 1:length(targets)) {
         target <- targets[[ti]]
         rtrange <- target$rtrange
-        if(rtrange[1] < scanrange[1]) {
-            cat("Warning: scanrange of ", rtrange[1], "less than minimum rtrange in file. Target ignored.\n")
-            next
-        }
-        if(rtrange[2] > scanrange[2]) {
-            cat("Warning: scanrange of ", rtrange[2], "greater than maximum rtrange in file. Target ignored.\n")
-            next
-        }
         mzrange <- target$mzrange
         t_peakwidth <- target$peakwidth
         if (is.null(t_peakwidth)) t_peakwidth <- peakwidth
@@ -1194,6 +1186,11 @@ setMethod("findPeaks.centWave", "xcmsRaw", function(object, ppm=25, peakwidth=c(
         si <- which(object@scantime >= rtrange[1] & object@scantime <= rtrange[2])
         scmin <- si[1]
         scmax <- si[length(si)]
+
+        if(is.na(scmin) || is.na(scmax)) {
+            cat("Warning: scanrange ", rtrange, "outside rtrange in file. Target ignored.\n")
+            next
+        }
 
         rawmz <- rawMZ(object, mzrange=mzrange, scanrange=c(scmin, scmax))
         gz <- which(rawmz > 0)


### PR DESCRIPTION
If a target is provided with a scanrange outside of a mzml file, things crash. This skips those targets with a warning.